### PR TITLE
Add rel noopener to external links

### DIFF
--- a/src/containers/About.vue
+++ b/src/containers/About.vue
@@ -17,7 +17,11 @@ import resume from "@/data/resume.json";
           <img width="32" height="32" :src="`${simpleIcon}/${icon}`" :alt="icon" />
         </div>
       </div>
-      <a target="_blank" href="https://registry.jsonresume.org/deanufriana">
+        <a
+          target="_blank"
+          rel="noopener noreferrer"
+          href="https://registry.jsonresume.org/deanufriana"
+        >
         <Button size="lg" variant="secondary">Download CV</Button>
       </a>
     </div>

--- a/src/containers/Experience.vue
+++ b/src/containers/Experience.vue
@@ -20,7 +20,12 @@ const formatDate = (date: string | undefined | null) => {
         <Card v-for="work in resume.work" class="min-w-[90%] bg-gray-700 border-blue-200 rounded-l text-white snap-start md:min-w-[32%]" :key="work.name">
           <CardContent class="flex flex-col gap-1">
             <h3 class="flex justify-between gap-2 flex-wrap mb-3">
-              <a class="text-2xl md:text-4xl font-bold text-blue-600 hover:text-blue-400" :href="work.url" target="_blank">{{ work.name }}</a>
+              <a
+                class="text-2xl md:text-4xl font-bold text-blue-600 hover:text-blue-400"
+                :href="work.url"
+                target="_blank"
+                rel="noopener noreferrer"
+              >{{ work.name }}</a>
               <span>
                 <Badge>{{ work.position }}</Badge>
               </span>

--- a/src/containers/Footer.vue
+++ b/src/containers/Footer.vue
@@ -8,7 +8,7 @@ import contacts from "@/data/contacts.json";
     <h3 class="text-lg font-bold">Contact me</h3>
     <div class="flex gap-4">
       <div v-for="contact in contacts" :key="contact.icon">
-        <a :href="contact.url" target="_blank">
+        <a :href="contact.url" target="_blank" rel="noopener noreferrer">
           <img width="32" height="32" :src="`${simpleIcon}/${contact.icon}`" :alt="contact.icon" />
         </a>
       </div>


### PR DESCRIPTION
## Summary
- prevent reverse-tabnabbing by adding `rel="noopener noreferrer"` to external links in About, Experience, and Footer components

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68af18b43588833089364964c804627f