### PR TITLE
Fix resume highlight typo

### DIFF
--- a/src/data/resume.json
+++ b/src/data/resume.json
@@ -33,7 +33,7 @@
                 "Proficiently developed integration tests using Playwright to validate software functionality and reliability.",
                 "Took charge of refining the UI Detail page, implementing improvements for an enhanced user experience.",
                 "Conducted comprehensive software analysis to identify opportunities for performance enhancement and implemented strategies to optimize system efficiency.",
-                "Refactored the review page, hall of fame page, and latet to the latest Vue version, improving performance and reusability by creating modular components",
+                "Refactored the review page, hall of fame page, and latest to the latest Vue version, improving performance and reusability by creating modular components",
                 "Redesigned and migrated the Review Center page from Java to Vue, enhancing user experience and modernizing the technology stack",
                 "Maintained existing features and developed new functionalities based on product manager requests, ensuring smooth and efficient implementation"
             ],


### PR DESCRIPTION
## Summary
- fix typo in resume highlight for Blibli job entry

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af19a6a0708330bd41184ff988956d