### PR TITLE
docs: correct dev server url

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ This project is intentionally designed to explore:
    ```
 
 4. **Open your browser**
-   Navigate to `http://localhost:3000` to view your site
+   Navigate to `http://localhost:4321` (or the port shown after running `npm run dev`) to view your site. You can override the port with `--port`, e.g., `npm run dev -- --port 3000`.
 
 ## 🎯 Available Scripts
 


### PR DESCRIPTION
## Summary
- fix README to mention Astro's default port and note how to override it

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68af19a5cbf88330a762d4fff4b76712